### PR TITLE
[ ipkg ] specify codegen

### DIFF
--- a/tyttp.ipkg
+++ b/tyttp.ipkg
@@ -35,6 +35,8 @@ depends = base
   , apache-mime-types
   , contrib
 
+opts      = "--codegen node"
+
 sourcedir = "src"
 
 main = Main


### PR DESCRIPTION
As discussed on Discord, pack needs an explicitly set codegen in the `.ipkg` file in order to build and install this library.