### PR TITLE
[ refactor ] remove contrib dependency

### DIFF
--- a/json/tyttp-json.ipkg
+++ b/json/tyttp-json.ipkg
@@ -5,7 +5,6 @@ modules = TyTTP.HTTP.Consumer.JSON
 
 depends = tyttp
   , promise
-  , contrib
   , json
   , sop
   , elab-util

--- a/src/TyTTP/Core/Context.idr
+++ b/src/TyTTP/Core/Context.idr
@@ -18,10 +18,10 @@ export
 Bifunctor (Context me u v h1 s h2) where
   bimap f g step = { request $= map f, response $= map g } step
 
-private
+export
 infixr 0 :>
 
-private
+export
 infixr 0 :>>
 
 export

--- a/src/TyTTP/Core/Context.idr
+++ b/src/TyTTP/Core/Context.idr
@@ -18,7 +18,11 @@ export
 Bifunctor (Context me u v h1 s h2) where
   bimap f g step = { request $= map f, response $= map g } step
 
-infixr 0 :>, :>>
+private
+infixr 0 :>
+
+private
+infixr 0 :>>
 
 export
 (:>) : MonadTrans t

--- a/tyttp.ipkg
+++ b/tyttp.ipkg
@@ -20,7 +20,6 @@ modules = TyTTP
 
 depends = base
   , apache-mime-types
-  , contrib
   , promise
 
 sourcedir = "src"


### PR DESCRIPTION
This PR removes the [contrib](https://github.com/idris-lang/Idris2/tree/main/libs/contrib) dependency from [tyttp](https://github.com/kbertalan/tyttp) and [tyttp-json](https://github.com/kbertalan/tyttp/tree/main/json).

This PR also resolves a fixity warning when building.