### PR TITLE
path params example

### DIFF
--- a/adapter-node/src/Main.idr
+++ b/adapter-node/src/Main.idr
@@ -1,5 +1,7 @@
 module Main
 
+import Data.List
+
 import TyTTP.Adapter.Node.HTTP
 import TyTTP.HTTP
 import TyTTP.URL
@@ -29,6 +31,14 @@ main = do
         , get $ pattern "/" $ \ctx => do
             putStrLn "serving root"
             sendText "welcome adventurer" ctx >>= status OK
+        , get $ pattern "/example/{id}" $ \ctx => do
+            let maybeId = lookup "id" ctx.request.url.path.params
+            putStrLn $ "parameters: \{show ctx.request.url.path.params}"
+            sendText "id: \{show maybeId}" ctx >>= status OK
+        , get $ pattern "/example/{id}/*" $ \ctx => do
+            let maybeId = lookup "id" ctx.request.url.path.params
+            putStrLn $ "parameters: \{show ctx.request.url.path.params} and rest: \{ctx.request.url.path.rest}"
+            sendText "id: \{show maybeId} and rest: \{show ctx.request.url.path.rest}" ctx >>= status OK
         ]
 
   let Just port = options.listenOptions.port | Nothing => pure ()

--- a/src/TyTTP/URL/Path.idr
+++ b/src/TyTTP/URL/Path.idr
@@ -110,9 +110,10 @@ matcher s (MkParsedPattern ls) = go ls (unpack s) $ MkPath s [] ""
         then Nothing
         else go (Literal l :: ps) (assert_smaller xs remaining) $ { params $= ((pack param, pack value)::) } p
     go (Param param :: Nil) xs p =
-      if null xs
+      let (value, remaining) = List.break (=='/') xs
+      in if null value || not (null remaining)
       then Nothing
-      else Just $ { params $= ((pack param, pack xs)::) } p
+      else Just $ { params $= ((pack param, pack value)::) } p
     go (Rest :: Nil) xs p = Just $ { rest := pack xs } p
     go _ _ _ = Nothing
 


### PR DESCRIPTION
Provides basic example of using path params as requested in https://github.com/kbertalan/tyttp/issues/16

Fixes the case when a parameter consumed all the remaining string, ie: its value contained a `/`.